### PR TITLE
Add Encyclopedia Entry on Operators in SQL

### DIFF
--- a/content/sql/encyclopedia/operators-in-sql.md
+++ b/content/sql/encyclopedia/operators-in-sql.md
@@ -1,0 +1,46 @@
+---
+Title: "Operators in SQL"
+Subjects:
+  - "Data Science"
+  - "Computer Science"
+Tags: 
+  - "Operators"
+Catalog Content:
+  - "https://www.codecademy.com/learn/learn-python-3"
+  - "https://www.codecademy.com/learn/paths/data-science"
+  - "https://www.codecademy.com/learn/paths/computer-science"
+---
+
+## Arithmetic Operators
+
+Arithmetic operators are used to perform arithmetic on numeric types:
+
+* `+` addition
+* `-` subtraction
+* `*` multiplication
+* `/` division
+* `%` modulo
+
+```sql
+-- Addition
+5 + 5
+-- Subtraction
+10 - 5
+--  Multiplication
+5 * 10
+-- Division
+10 / 5
+-- Modulo
+10 % 5
+```
+
+## Comparison Operators
+
+Comparison operators can be used to compare two values:
+
+- `=` equal to
+- `!=`, `<>` not equal
+- `>` greater than
+- `<` less than
+- `>=` greater than or equal to
+- `<=` less than or equal to


### PR DESCRIPTION
A small PR on operators in SQL to check my understanding on workflows and content standards. I based this off of the existing operator entries for other languages and therefore stuck to only arithmetic operations, leaving out logical, set, and string operations. Also I only added common operators that I believe exist in all SQL dialects, so this work excludes PostgreSQL's square root (|/) and exponent (^) operators for example.

Let me know if I should include the above in this entry or suggest another entry topic instead. Also guidance on how to determine what SQL features are canonical would be appreciated as well.