### PR TITLE
Update `upper()` document for python due to inaccurate description

### DIFF
--- a/content/python/concepts/strings/terms/upper/upper.md
+++ b/content/python/concepts/strings/terms/upper/upper.md
@@ -13,7 +13,7 @@ CatalogContent:
   - 'paths/analyze-data-with-python'
 ---
 
-Takes a string, and returns a copy of that string in which all letters are lowercase. Numbers and symbols are not changed.
+Takes a string, and returns a copy of that string in which all letters are uppercase. Numbers and symbols are not changed.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

I have edited the `upper()` file for Python, as there is a typo describing the string method. The method changes the lowercase characters of the existing string to uppercase, instead of lowercase as described in the current document. 

### Type of Change

- Editing an existing entry (fixing a typo)


### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.

