### PR TITLE
Add term entry for Single Inheritance in Python

### DIFF
--- a/content/python/concepts/inheritance/terms/single-inheritance/single-inheritance.md
+++ b/content/python/concepts/inheritance/terms/single-inheritance/single-inheritance.md
@@ -66,7 +66,6 @@ Barks
 - Both define a `speak()` method, but `Dog` overrides it to provide a more specific output.
 - This demonstrates how subclasses can customise inherited behaviour.
 
-
 ```codebyte/python
 class Vehicle:
   def start_engine(self):


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

This pull request adds a new term entry titled **"Single Inheritance"** under the path:
`content/python/concepts/inheritance/terms/single-inheritance/single-inheritance.md`

The entry includes:

* A clear and concise definition of single inheritance in Python
* A diagram illustrating the concept
* A `## Syntax` section with usage format
* An `## Example` with real-world context
* A `## Codebyte` section with runnable Python code
* Proper metadata, subjects, tags, and catalog content
* Compliance with Codecademy’s content, markdown, and style guidelines

### Issue Solved

Closes #7078

### Type of Change

* [x] Adding a new entry
* [ ] Editing an existing entry (fixing a typo, bug, issues, etc)
* [ ] Updating the documentation

### Checklist

* [x] All writings are my own.
* [x] My entry follows the Codecademy Docs style guide.
* [x] My changes generate no new warnings.
* [x] I have performed a self-review of my own writing and code.
* [x] I have checked my entry and corrected any misspellings.
* [x] I have made corresponding changes to the documentation if needed.
* [x] I have confirmed my changes are not being pushed from my forked `main` branch.
* [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
* [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

