### PR TITLE
[Entry] C++ unordered map: hash_function()

### DIFF
--- a/content/cpp/concepts/unordered-map/terms/hash-function/hash-function.md
+++ b/content/cpp/concepts/unordered-map/terms/hash-function/hash-function.md
@@ -26,7 +26,7 @@ The `hash_function()` method takes no parameters.
 
 **Return value:**
 
-Returns the hash function used by the unordered\_map. The return type is the function object used for hashing keys.
+Returns the hash function used by the unordered_map. The return type is the function object used for hashing keys.
 
 ## Example 1: Default hash function
 
@@ -79,7 +79,7 @@ int main() {
 The output of the code is:
 
 ```shell
-Hash for 'apple': 7562681486644061055  
+Hash for 'apple': 7562681486644061055
 Hash for 'banana': 680920345727384150
 ```
 
@@ -111,14 +111,14 @@ The hash function often returns the value itself for integer keys, as integers m
 
 ## Frequently asked questions
 
-### 1. Can a custom hash function be used in unordered\_map?
+### 1. Can a custom hash function be used in unordered_map?
 
 Yes. A user-defined hash function can be passed as a template parameter when defining the map.
 
-### 2. Is hash\_function() always std::hash?
+### 2. Is hash_function() always std::hash?
 
-By default, yes. But if a custom hash is provided during map declaration, hash\_function() returns that.
+By default, yes. But if a custom hash is provided during map declaration, hash_function() returns that.
 
-### 3. When is hash\_function() useful?
+### 3. When is hash_function() useful?
 
 When debugging or when needing to understand how keys are being distributed across buckets internally.


### PR DESCRIPTION
<!--
👋 Hi, thanks for submitting a PR to Codecademy Docs! 💖
Please fill out all fields below to ensure your PR is reviewed quickly.

**IMPORTANT**

If you would like to receive credit for your contribution to an entry, make sure to have your Codecademy user profile linked to your GitHub account:

1. Go to your Codecademy dashboard.
2. Click on your profile image in the top-right and then choose "Profile".
3. Then click "Edit Profile".
4. In the "GitHub Username" field, add your username (without the @).
5. Click "Save Changes"

Of course, you can opt not to do this and be listed as an "Anonymous contributor", instead. :)
-->

### Description

[Entry] C++ unordered map: hash_function()

### Issue Solved

Closes #7145 

### Type of Change

<!--- Please delete or cross off the bullet point(s) that are irrelevant to this PR: -->

- Adding a new entry


### Checklist

<!-- Please check ALL the boxes: -->

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [ ] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.

<!--
Having trouble with the PR checker? Here are some common issues and resolutions:

- verify_formatting is failing
  - run `yarn format path/to/markdown/file.md` or `yarn format:all` and commit the results
- verify_lint is failing
  - same as above
  - if verify_lint is still failing, running `yarn lint` locally should let you know what needs to be changed by hand
- test is failing
  - ensure any new markdown files have a `Title` and `Description` defined in their metadata
  - ensure any new markdown files only contain alphanumerics and dashes in their file names and have the same name as their parent directory
  - if that looks ok, running `yarn test` locally should let you know what the issue is
-->
