### PR TITLE
feat(docs): Add PyTorch logical_or term entry (closes #7786)

### DIFF
--- a/content/pytorch/concepts/tensor-operations/terms/logical-or/logical-or.md
+++ b/content/pytorch/concepts/tensor-operations/terms/logical-or/logical-or.md
@@ -29,6 +29,24 @@ This operation can be used either as a function in the torch module or as a tens
 - `other` (Tensor): The second tensor to compare.
 - `out` (Tensor, optional): Tensor to store the output.
 
+## Example
+
+```python
+import torch
+
+# Example 1: Using boolean tensors
+a = torch.tensor([True, False, True, False])
+b = torch.tensor([True, True, False, False])
+print(torch.logical_or(a, b))
+# Output: tensor([True, True, True, False])
+
+# Example 2: Using integer tensors
+x = torch.tensor([1, 0, 0, 7])
+y = torch.tensor([0, 0, 3, 0])
+print(x.logical_or(y))
+# Output: tensor([True, False, True, True])
+```
+
 ## Codebyte Example
 
 ```codebyte/python


### PR DESCRIPTION
Adds a new term entry for logical_or() in PyTorch. This entry introduces the concept of element-wise logical OR operations on tensors, explains the syntax for both the function and tensor method forms, and provides runnable examples demonstrating boolean tensors, integer tensors, and broadcasting behavior. The entry follows the term entry template, content standards, and markdown style guide for PyTorch tensor operations.