### PR TITLE
docs: Add PyTorch Tensor Operations entry for .rad2deg() (#7852)

### DIFF
--- a/content/pytorch/concepts/tensor-operations/terms/rad2deg/rad2deg.md
+++ b/content/pytorch/concepts/tensor-operations/terms/rad2deg/rad2deg.md
@@ -14,9 +14,9 @@ CatalogContent:
   - 'paths/data-science'
 ---
 
-The **`.rad2deg()`** method in PyTorch converts the elements of a tensor from **radians to degrees**. This is useful for trigonometric and rotational operations when working with angular measurements. The operation is performed element-wise, meaning it applies the conversion formula ($$\text{degrees} = \text{radians} \times \frac{180}{\pi}$$) to every value in the tensor, returning a new tensor with the results.
+The **`.rad2deg()`** function in PyTorch converts the elements of a tensor from radians to degrees. This is useful for trigonometric and rotational operations when working with angular measurements. The operation is performed element-wise, meaning it applies the conversion formula ($$\text{degrees} = \text{radians} \times \frac{180}{\pi}$$) to every value in the tensor, returning a new tensor with the results.
 
-This method is available for tensors with floating-point data types such as `torch.float16`, `torch.float32`, or `torch.float64`.
+This function is available for tensors with floating-point data types such as `torch.float16`, `torch.float32`, or `torch.float64`.
 
 ## Syntax
 
@@ -36,15 +36,15 @@ Returns a tensor containing the degree equivalents of the original tensor's elem
 
 This example demonstrates how to use `.rad2deg()` to convert common angular values ($\pi$ radians and $\frac{\pi}{2}$ radians) into degrees:
 
-```python
+```py
 import torch
 import math
 
 # Create a tensor with values in radians
 radians_tensor = torch.tensor([
-    math.pi / 2, 
-    math.pi,     
-    0.0           
+  math.pi / 2,
+  math.pi,
+  0.0
 ])
 
 print("Original Tensor (Radians):")


### PR DESCRIPTION
Closes #7852

This Pull Request adds the new documentation entry for the **PyTorch tensor method, `.rad2deg()`**. This submission was made from a fresh repository clone to ensure a clean history.

### Implementation Details:
* **File Path:** Created the file at the required location: `docs/content/pytorch/concepts/tensor-operations/terms/rad2deg/rad2deg.md`.
* **Structure:** The entry includes the mandatory sections: Introduction, Syntax, and Example.
* **Content:** Provides an element-wise conversion example from radians to degrees using `torch.rad2deg()`.
* **Compliance:** Follows the Codecademy documentation and Markdown style guides.