### PR TITLE
add .ndim docs to python numpy array (#7821)

### DIFF
--- a/content/numpy/concepts/ndarray/terms/ndim/ndim.md
+++ b/content/numpy/concepts/ndarray/terms/ndim/ndim.md
@@ -4,18 +4,17 @@ Description: 'Returns the number of dimensions (axes) of a NumPy array.'
 Subjects:
   - 'Code Foundations'
   - 'Computer Science'
-  - 'Data Science'
 Tags:
   - 'Arrays'
   - 'Attributes'
-  - 'Shape'
   - 'NumPy'
+  - 'Shape'
 CatalogContent:
   - 'learn-python-3'
   - 'paths/computer-science'
 ---
 
-The **`ndim`** attribute returns the number of dimensions (axes) of a [NumPy array](https://www.codecademy.com/resources/docs/numpy/ndarray). A 1D array acts like a list, a 2D array forms a matrix, and higher dimensions represent tensors which are common in data science and machine learning.
+The **`ndim`** attribute returns the total number of dimensions (axes) of a NumPy array. A 1D array acts like a list, a 2D array forms a matrix, and higher dimensions represent tensors which are common in data science and machine learning.
 
 ## Syntax
 
@@ -25,7 +24,7 @@ ndarray.ndim
 
 **Parameters:**
 
-The `.ndim` attribute takes no parameters.
+The `ndim` attribute takes no parameters.
 
 **Return value:**
 


### PR DESCRIPTION
### Description
Added a new term entry for NumPy's `ndarray.ndim` that explains how to view the number of dimensions of an array. The entry includes:

- A concise definition describing that `.ndim` returns an integer representing the number of dimensions.
- A ## Syntax section with the attribute signature and notes that it takes no parameters.
- Multiple ## Examples showing 0D, 1D, 2D, and 3D arrays.
- A ## Codebyte section demonstrating practical usage of `.ndim` in NumPy operations and conditional checks.


### Issue Solved
Closes #7821 

### Type of Change
- Adding a new entry
- Updating the documentation

### Checklist
- [ x] All writings are my own.
- [x ] My entry follows the Codecademy Docs style guide.
- [ x] My changes generate no new warnings.
- [x ] I have performed a self-review of my own writing and code.
- [x ] I have checked my entry and corrected any misspellings.
- [x ] I have made corresponding changes to the documentation if needed.
- [x ] I have confirmed my changes are not being pushed from my forked `main` branch.
- [ x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [ x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.