### PR TITLE
Add documentation for the Math.Cbrt() method, including syntax, examples, and usage

### DIFF
--- a/content/c-sharp/concepts/math-functions/terms/cbrt/cbrt.md
+++ b/content/c-sharp/concepts/math-functions/terms/cbrt/cbrt.md
@@ -2,18 +2,18 @@
 Title: 'Cbrt()'
 Description: 'Returns the cube root of the given number.'
 Subjects:
-  - 'Computer Science'
   - 'Code Foundations'
+  - 'Computer Science'
 Tags:
   - 'Arithmetic'
-  - 'Numbers'
   - 'Methods'
+  - 'Numbers'
 CatalogContent:
   - 'learn-c-sharp'
   - 'paths/computer-science'
 ---
 
-The **`Math.Cbrt()`** method in C# returns the cube root of a given number. It handles positive, negative, and special floating-point values such as `NaN` and infinities.
+The **`Math.Cbrt()`** [method](https://www.codecademy.com/resources/docs/c-sharp/methods) in C# returns the cube root of a given number. It handles positive, negative, and special floating-point values such as `NaN` and infinities.
 
 ## Syntax
 
@@ -27,12 +27,12 @@ Math.Cbrt(double x)
 
 **Return value:**
 
-The function will return a value of type `double` unless the value passed is one of the following:
+The method will return a value of [type](https://www.codecademy.com/resources/docs/c-sharp/data-types) `double` unless the value passed is one of the following:
 
-- If `x` is `NaN`, the function will return `NaN`.
-- If `x` is `PositiveInfinity`, the function will return `PositiveInfinity`.
-- If `x` is `NegativeInfinity`, the function will return `NegativeInfinity`.
-- If `x` is negative, returns the real cube root (a negative number).
+- If `x` is `NaN`, the method will return `NaN`.
+- If `x` is `PositiveInfinity`, the method will return `PositiveInfinity`.
+- If `x` is `NegativeInfinity`, the method will return `NegativeInfinity`.
+- If `x` is negative, the method will return the real cube root (a negative number).
 
 ## Example
 


### PR DESCRIPTION
### Description

Added a new term entry for the `Math.Cbrt()` method under C# math-functions. This entry explains how to calculate the cube root of a number using the built-in Math library. The documentation includes a detailed syntax section, a working example with multiple test cases, and an interactive codebyte for users to try out the method.

### Issue Solved

Closes #7948

### Type of Change

- Adding a new entry

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.