### PR TITLE
Fix typo: Add period before Abs() in title (fixes #7972)

### DIFF
--- a/content/c-sharp/concepts/math-functions/terms/abs/abs.md
+++ b/content/c-sharp/concepts/math-functions/terms/abs/abs.md
@@ -1,5 +1,5 @@
 ---
-Title: 'Abs()'
+Title:.'.Abs()'
 Description: 'Returns the absolute value of a specified number.'
 Subjects:
   - 'Computer Science'


### PR DESCRIPTION
### Description
Added a period (.) before Abs() in the title to match the naming convention used in other entries in the math-functions directory.

### Issue Solved
Closes #7972

### Type of Change
- Editing an existing entry (fixing a typo, bug, issues, etc)

### Checklist
- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.