### PR TITLE
Add islessgreater() term entry for C++ math-functions

### DIFF
--- a/content/cpp/concepts/math-functions/terms/islessgreater/islessgreater.md
+++ b/content/cpp/concepts/math-functions/terms/islessgreater/islessgreater.md
@@ -18,6 +18,7 @@ The **`islessgreater()`** function determines whether a floating-point value is 
 ```pseudo
 islessgreater(x, y)
 ```
+
 **Parameters:**
 
 - `x`: A floating-point or integer value to compare.


### PR DESCRIPTION
Added documentation for the `islessgreater()` function including:
- Description of the comparison behavior without floating-point exceptions
- Syntax and parameters
- Examples showing basic usage with different values
- Codebyte example with various data types and edge cases including NaN

### Description

This PR adds a new term entry for the `islessgreater()` function under C++ math-functions as requested in issue #7996. The documentation provides a comprehensive overview of this function, which determines whether a value is less than or greater than another without raising `FE_INVALID` exceptions. The entry includes detailed explanations of how this function safely handles `NaN` values, along with practical examples demonstrating its usage with different floating-point types.

### Issue Solved

Closes #7996

### Type of Change

- Adding a new entry

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.