### PR TITLE
docs: Add C++ unordered_set::cbegin() term entry (#8031)

### DIFF
--- a/content/cpp/concepts/unordered-set/terms/cbegin/cbegin.md
+++ b/content/cpp/concepts/unordered-set/terms/cbegin/cbegin.md
@@ -19,7 +19,7 @@ The **`cbegin()`** method returns a constant iterator that points to the first e
 
 ```pseudo
 unordered_set_name.cbegin(n);
-````
+```
 
 **Return value:**
 
@@ -33,7 +33,7 @@ unordered_set_name.cbegin(n);
 
 **Parameters:**
 
-* `n` (size_type): The bucket index. Must be less than `bucket_count()`.
+- `n` (size_type): The bucket index. Must be less than `bucket_count()`.
 
 **Return value:**
 


### PR DESCRIPTION
Closes #8031

This PR adds the documentation entry for the **C++ `unordered_set::cbegin()`** method.

### Implementation Details:
* **File Path:** Created the file at the required location: `docs/content/cpp/concepts/unordered-set/terms/cbegin/cbegin.md`.
* **Core Concept:** The entry clarifies the use of the **constant iterator (`const_iterator`)** returned by `cbegin()` for safe, read-only iteration over the set's elements.
* **Structure:** Includes the mandatory Description, Syntax, and Example sections, along with the required Codebyte.