### PR TITLE
Add PyTorch .sgn() tensor operation documentation

### DIFF
--- a/content/pytorch/concepts/tensor-operations/terms/sgn/sgn.md
+++ b/content/pytorch/concepts/tensor-operations/terms/sgn/sgn.md
@@ -14,7 +14,7 @@ CatalogContent:
   - 'paths/data-science'
 ---
 
-The **`.sgn()`** function computes the sign of each element in the input [tensor](https://www.codecademy.com/resources/docs/pytorch/tensors), applied element-wise. For real-valued tensors, it returns -1 for negative values, 0 for zero, and 1 for positive values. For complex-valued tensors, it returns the complex sign (the tensor divided by its absolute value), which gives the unit vector in the direction of each complex number.
+The **`.sgn()`** function computes the sign of each element in the input [tensor](https://www.codecademy.com/resources/docs/pytorch/tensors), applied element-wise. For real-valued tensors, it returns `-1` for negative values, `0` for zero, and `1` for positive values. For complex-valued tensors, it returns the complex sign (the tensor divided by its absolute value), which gives the unit vector in the direction of each complex number.
 
 ## Syntax
 


### PR DESCRIPTION
### Description

Added term entry for PyTorch's `.sgn()` function at `content/pytorch/concepts/tensor-operations/terms/sgn/sgn.md`.

The function computes element-wise sign:
- Real tensors: returns -1, 0, or 1
- Complex tensors: returns unit vector (x/|x|)

Includes three examples demonstrating 1D real tensors, 2D tensors, and complex number behavior.

Metadata follows patterns from similar operations (`.neg()`, `.positive()`): Computer Science and Data Science subjects, Deep Learning/Methods/PyTorch/Tensor tags.

### Issue Solved

Closes #8082

### Type of Change

- Adding a new entry

### Checklist

- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.