### PR TITLE
[Term Entry] Dart Queue: .first

### DIFF
--- a/content/dart/concepts/queue/terms/first/first.md
+++ b/content/dart/concepts/queue/terms/first/first.md
@@ -16,6 +16,7 @@ CatalogContent:
 In Dart, the **`.first`** property returns the first element in a `Queue`. This property is part of the `Queue` class under the `dart:collection` library.
 
 ## Syntax
+
 ```pseudo
 queue.first;
 ```
@@ -26,9 +27,10 @@ Returns the first element in the queue.
 
 > **Note:** If the queue is empty, accessing this property throws a `StateError`.
 
-## Example
+## Example: Accessing the First Element of a `Queue`
 
 The following example demonstrates the usage of the `.first` property:
+
 ```dart
 import 'dart:collection';
 
@@ -40,17 +42,11 @@ void main() {
   numbers.add(40);
 
   print("First element: ${numbers.first}");
-
-  // Modifying the first element
-  numbers.first = 5;
-  print("Updated first element: ${numbers.first}");
 }
 ```
 
 The output for the above code is as follows:
+
 ```shell
 First element: 10
-Updated first element: 5
 ```
-
-> **Note:** The `.first` property can also be used to modify the first element of the queue, as shown in the example above.


### PR DESCRIPTION
### Description
This PR adds a new term entry for the `.first` property in Dart's Queue concept.

**Changes made:**
- Created a new file: `docs/content/dart/concepts/queue/terms/first/first.md`
- Added an introduction explaining the `.first` property
- Included a `Syntax` section with clear return value description
- Provided an `Example` section demonstrating practical usage of the property, including how to modify the first element
- Added a note about `StateError` when the queue is empty
- Added a note about the mutability of the `.first` property

### Issue Solved
Closes #8150 

### Type of Change
- Adding a new entry

### Checklist
- [x] All writings are my own.
- [x] My entry follows the Codecademy Docs style guide.
- [x] My changes generate no new warnings.
- [x] I have performed a self-review of my own writing and code.
- [x] I have checked my entry and corrected any misspellings.
- [x] I have made corresponding changes to the documentation if needed.
- [x] I have confirmed my changes are not being pushed from my forked `main` branch.
- [x] I have confirmed that I'm pushing from a new branch named after the changes I'm making.
- [x] I have linked any issues that are relevant to this PR in the `Issues Solved` section.